### PR TITLE
Parse tag description for php documentor tag types

### DIFF
--- a/docs/tags/example.md
+++ b/docs/tags/example.md
@@ -27,7 +27,8 @@ That results in
     'example' => [
         'location' => 'some_dir/some_file.php',
         'start_line' => 12,
-        'number_of_lines' => 24
+        'number_of_lines' => 24,
+        'description' => 'Misterious foo function in action'
     ]
 ]
 ```

--- a/docs/tags/method.md
+++ b/docs/tags/method.md
@@ -41,7 +41,8 @@ Result:
                 'name' => 'third',
                 'default' => '[]'
             ]
-        ]
+        ],
+        'description' => 'Method to obtain some extra bar'
     ]
 ]
 ```

--- a/docs/tags/var.md
+++ b/docs/tags/var.md
@@ -5,7 +5,7 @@ Is used for processing `@var`, `@property` and `@param` tags.
 
 ```php
 /**
- * @property Bar $value
+ * @property Bar $value  Some Bar thing to use
  */
 class Foo
 {
@@ -32,7 +32,8 @@ Result:
     'property' => [
         'type' => 'Zoo\Baz\Bar',
         'name' => 'value',
-        'some-more' => 'data'
+        'some-more' => 'data',
+        'description' => 'Some Bar thing to use'
     ]
 ]
 ```

--- a/src/Tag/PhpDocumentor/ExampleTag.php
+++ b/src/Tag/PhpDocumentor/ExampleTag.php
@@ -22,26 +22,37 @@ class ExampleTag extends AbstractTag
      */
     public function process(array $notations, string $value): array
     {
-        $regexp = '/^(?<location>(?:[^"]\S*|"[^"]+"))(?:\s*(?<start_line>\d+)(?:\s*(?<number_of_lines>\d+))?)?/';
+        $regexp = '/^(?<location>(?:[^"]\S*|"[^"]+"))(?:\s*(?<start_line>\d+)(?:\s*(?<number_of_lines>\d+))?)?(?:\s*(?<description>.+))?/';
 
         if (!preg_match($regexp, $value, $matches)) {
             throw new PhpdocException("Failed to parse '@{$this->name} $value': invalid syntax");
         }
 
-        $matches['location'] = trim($matches['location'], '"');
-
-        if (isset($matches['start_line'])) {
-            $matches['start_line'] = (int)$matches['start_line'];
-        }
-
-        if (isset($matches['number_of_lines'])) {
-            $matches['number_of_lines'] = (int)$matches['number_of_lines'];
-        }
-
-        $matches = array_only($matches, ['location', 'start_line', 'number_of_lines']);
+        $this->normalizeValues($matches);
+        $matches = array_only($matches, ['location', 'start_line', 'number_of_lines', 'description']);
 
         $notations[$this->name] = $matches;
 
         return $notations;
+    }
+
+    /**
+     * Normalize parsed values
+     *
+     * @param array $values
+     */
+    protected function normalizeValues(array &$values): void
+    {
+        $values['location'] = trim($values['location'], '"');
+
+        foreach (['start_line', 'number_of_lines'] as $name) {
+            if (!isset($values[$name])) continue;
+
+            if ($values[$name] === '') {
+                unset($values[$name]);
+            } else {
+                $values[$name] = (int)$values[$name];
+            }
+        }
     }
 }

--- a/src/Tag/PhpDocumentor/VarTag.php
+++ b/src/Tag/PhpDocumentor/VarTag.php
@@ -58,21 +58,33 @@ class VarTag extends AbstractTag
      */
     public function process(array $notations, string $value): array
     {
-        $regexp = '/^(?:(?<type>[^$\s]+)\s*)?(?:\$(?<name>\w+)\s*)?(?:"(?<id>[^"]+)")?/';
+        $regexp = '/^(?:(?<type>[^$\s]+)\s*)?(?:\$(?<name>\w+)\s*)?(?:"(?<id>[^"]+)"\s*)?(?:(?<description>.+))?/';
         preg_match($regexp, $value, $props); //regexp won't fail
 
-        if (isset($props['type']) && $props['type'] === '') {
-            unset($props['type']);
-        }
+        $this->removeEmptyValues($props);
 
         if (isset($props['type']) && isset($this->fqsenConvertor)) {
             $props['type'] = call_user_func($this->fqsenConvertor, $props['type']);
         }
 
-        $props = array_only($props, ['type', 'name', 'id']);
+        $props = array_only($props, ['type', 'name', 'id', 'description']);
 
         $notations[$this->name] = $props + $this->additional;
 
         return $notations;
+    }
+
+    /**
+     * Remove empty values from parsed data
+     *
+     * @param array $props
+     */
+    protected function removeEmptyValues(array &$props): void
+    {
+        foreach (['type', 'name', 'id'] as $name) {
+            if (isset($props[$name]) && $props[$name] === '') {
+                unset($props[$name]);
+            }
+        }
     }
 }

--- a/tests/Tag/PhpDocumentor/ExampleTagTest.php
+++ b/tests/Tag/PhpDocumentor/ExampleTagTest.php
@@ -61,13 +61,25 @@ class ExampleTagTest extends TestCase
                 ]
             ],
             [
+                '"some dir/and file.php" 47 And following description',
+                [
+                    'some' => 'value',
+                    'foo' => [
+                        'location' => 'some dir/and file.php',
+                        'start_line' => 47,
+                        'description' => 'And following description'
+                    ]
+                ]
+            ],
+            [
                 '"some dir/and file.php" 47 39 And following description',
                 [
                     'some' => 'value',
                     'foo' => [
                         'location' => 'some dir/and file.php',
                         'start_line' => 47,
-                        'number_of_lines' => 39
+                        'number_of_lines' => 39,
+                        'description' => 'And following description'
                     ]
                 ]
             ],
@@ -76,7 +88,8 @@ class ExampleTagTest extends TestCase
                 [
                     'some' => 'value',
                     'foo' => [
-                        'location' => 'some dir/and file.php'
+                        'location' => 'some dir/and file.php',
+                        'description' => 'And following description'
                     ]
                 ]
             ],

--- a/tests/Tag/PhpDocumentor/VarTagTest.php
+++ b/tests/Tag/PhpDocumentor/VarTagTest.php
@@ -32,13 +32,26 @@ class VarTagTest extends TestCase
     {
         return [
             [
+                'int Some description here',
+                null,
+                [],
+                [
+                    'some' => 'value',
+                    'foo' => [
+                        'type' => 'int',
+                        'description' => 'Some description here'
+                    ]
+                ]
+            ],
+            [
                 '$amount Some description here',
                 null,
                 [],
                 [
                     'some' => 'value',
                     'foo' => [
-                        'name' => 'amount'
+                        'name' => 'amount',
+                        'description' => 'Some description here'
                     ]
                 ]
             ],
@@ -82,6 +95,7 @@ class VarTagTest extends TestCase
                         'type' => 'some_namespace\\Foo',
                         'name' => 'amount',
                         'id' => 'some id',
+                        'description' => 'Some description here',
                         'any' => 'adds',
                         'little' => 'rats'
                     ]


### PR DESCRIPTION
I implemented `description` for `@method` tag when initially writing tests. So only `VarTag` and `ExampleTag` are done here.