### PR TITLE
Fix parsing when empty annotation is last

### DIFF
--- a/src/PhpdocParser.php
+++ b/src/PhpdocParser.php
@@ -93,8 +93,10 @@ class PhpdocParser
                 $result[] = $item;
             } else {
                 $lastIdx = count($result) - 1;
-                $result[$lastIdx]['value'] = trim($result[$lastIdx]['value'])
-                    . ' ' . trim($item['multiline_value']);
+                if (isset($result[$lastIdx]['value'])) {
+                    $result[$lastIdx]['value'] = trim($result[$lastIdx]['value'])
+                        . ' ' . trim($item['multiline_value']);
+                }
             }
         }
 


### PR DESCRIPTION
For example, having the Doctrine Required annotation at the end of the PHPDoc

Example of non-working PHPDoc:
```
/**
 * Test
 * @since 1.0.0
 * @var string
 * @Required
 */
```

Example of working PHPDoc:
```
/**
 * Test
 * @since 1.0.0
 * @Required
 * @var string
 */
```